### PR TITLE
Plot multiple results

### DIFF
--- a/plot_results.py
+++ b/plot_results.py
@@ -18,7 +18,7 @@ if (len(filenames) == 0):
 	filenames.extend(input("Enter file name(s): ").split())
 
 if (len(filenames) > 1):
-	average_p_col = int(input("1. Average results per column\n2. Show as subplots\nChoose: ")) == 1
+	average_p_col = int(input("1. Average results\n2. Show as subplots\nChoose: ")) == 1
 
 for file in filenames:
 	print("Reading", file, "as CSV file...")


### PR DESCRIPTION
Added support for reading and plotting multiple result csv file:
- Can plot single result file:
"*python plot_results.py file*"
- [x] Works on **Ubuntu**
- [x] Works on **Windows**
- Can plot multiple result files as separate subplots:
"*python plot_results.py file1 file2*"
enter "*2*" when prompted for separate plots
- [x] Works on **Ubuntu**
- [x] Works on **Windows**
- Can plot multiple result files as single averaged plot:
"*python plot_results.py file1 file2*"
enter "*1*" when prompted for average
- [x] Works on **Ubuntu**
- [x] Works on **Windows**